### PR TITLE
Add tolerance to numeric answers in exponential growth problem

### DIFF
--- a/sec_1.3/prob10.pg
+++ b/sec_1.3/prob10.pg
@@ -89,9 +89,9 @@ $t11 = $t1+1;
 $tfinal = log(30000/$initial)/$k;
 
 ANS(Formula("$initial*exp($k*t)")->cmp() );
-ANS(Compute("$initial*exp($k*$t11)")->cmp() );
-ANS(Compute("$initial*exp($k*$t11)*$k")->cmp() );
-ANS(Compute("ln(30000/$initial)/$k")->cmp() );
+ANS(Compute("$initial*exp($k*$t11)")->cmp(tolerance=>.005, tolType=>"relative") );
+ANS(Compute("$initial*exp($k*$t11)*$k")->cmp(tolerance=>.005, tolType=>"relative") );
+ANS(Compute("ln(30000/$initial)/$k")->cmp(tolerance=>.005, tolType=>"relative") );
 
 #####################################
 


### PR DESCRIPTION
Was working through problem 10 from section 1.3 and for the longest time could not understand why it would not accept my answer. 

Turns out despite allowing an approximated value of k in the first part, it requires the exact value of k for the rest of the problem. 

This change adds a small relative tolerance to the numeric answer checks to allow reasonable rounding while preserving correct grading and making answers more consistent for all parts of the question.